### PR TITLE
Updated to support Handlebars rc3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var vm = require('vm');
 
-var HANDLEBARSJS = fs.readFileSync(__dirname + '/vendor/handlebars-1.0.rc.1.js', 'utf8')
+var HANDLEBARSJS = fs.readFileSync(__dirname + '/vendor/handlebars-1.0.rc.3.js', 'utf8')
 var EMBERJS = fs.readFileSync(__dirname + '/vendor/ember-1.0.pre.min.js', 'utf8')
 
 module.exports = function (file) {


### PR DESCRIPTION
This update will allow ember-precompile to work with Handlebars 1.0 RC3, which will also allow your compiled templates to work with Ember 1.0 RC1.
