### PR TITLE
Added option to output the raw template without assigning it to the Ember.TEMPLATES object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ var vm = require('vm');
 var context_ = require('./context');
 
 module.exports = function (file, options) {
+  options = options || {};
+  
   var baseDir = options.baseDir || (path.dirname(file) + "/")
 
   var context = context_.getContext({
@@ -16,14 +18,19 @@ module.exports = function (file, options) {
 
   // compile the handlebars template inside the vm context
   vm.runInContext('templatejs = Ember.Handlebars.precompile(template).toString()', context)
-
+  
+  var template = 'Ember.Handlebars.template(' + context.templatejs + ')';
+  
+  // in case they don't want us to assign the template to the Ember.TEMPLATES object
+  if (options.outputRawTemplate) return template;
+  
   // extract the compiled template from the vm context and return it,
   // adding template to Ember.TEMPLATES when it is required
   var fileName = file.replace(baseDir, '')
   var templateName = fileName.replace(/\.(handlebars|hbs)$/, '').replace(/\./g, '/')
   var namedTemplateJs = 'Ember.TEMPLATES["' +
     templateName +
-    '"] = Ember.Handlebars.template(' + context.templatejs + ');'
+    '"] = ' + template + ';'
 
   return namedTemplateJs;
 }


### PR DESCRIPTION
This is needed for a build process I'm doing, others will likely want the same thing for various reasons. e.g. Ember will also resolve the template on the application namespace in the format `RouteNameTemplate`, just like Views, Controllers, etc.
