### PR TITLE
Needed for canSetNameOnInputs test

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -21,6 +21,8 @@ function getBaseSandbox() {
   var element = {
     firstChild: function () { return element },
     innerHTML: function () { return element },
+    setAttribute: function () { return element },
+    appendChild: function () { return element },
     // needed for "movesWhitespace()" test
     childNodes: [
       {nodeValue: 'Test: '},


### PR DESCRIPTION
This fix allows compiling to happen again in ember 1.1.2.
